### PR TITLE
Implement LangGraph-based RAG workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# rag-pipeline-with-agents
+# RAG Pipeline with LangGraph
+
+A retrieval-augmented generation system using LangGraph and Chroma.

--- a/rag_pipeline/__init__.py
+++ b/rag_pipeline/__init__.py
@@ -1,0 +1,14 @@
+from .config import EmbeddingConfig, VectorStoreConfig
+from .agents import RetrieverAgent, ReasoningAgent, SummarizerAgent
+from .memory import ConversationMemory
+from .workflow import RAGWorkflow
+
+__all__ = [
+    "EmbeddingConfig",
+    "VectorStoreConfig",
+    "RetrieverAgent",
+    "ReasoningAgent",
+    "SummarizerAgent",
+    "ConversationMemory",
+    "RAGWorkflow",
+]

--- a/rag_pipeline/agents.py
+++ b/rag_pipeline/agents.py
@@ -1,0 +1,42 @@
+from typing import Dict, List
+
+
+class RetrieverAgent:
+    """Fetches documents from the vector store."""
+
+    def __init__(self, collection, k: int = 5):
+        self.collection = collection
+        self.k = k
+
+    def retrieve(self, query: str, metadata: Dict | None = None) -> List[Dict]:
+        """Return documents relevant to the query."""
+        filters = {"where": metadata} if metadata else {}
+        result = self.collection.query(query_texts=[query], n_results=self.k, **filters)
+        documents = result["documents"][0]
+        metadatas = result["metadatas"][0]
+        distances = result["distances"][0]
+        return [{"text": d, "metadata": m, "score": 1 - s} for d, m, s in zip(documents, metadatas, distances)]
+
+
+class ReasoningAgent:
+    """Produces answers using retrieved documents and chat history."""
+
+    def __init__(self, llm):
+        self.llm = llm
+
+    def run(self, query: str, docs: List[Dict], history: List[Dict]) -> str:
+        """Generate an answer from the query and documents."""
+        context = "\n".join(d["text"] for d in docs)
+        messages = history + [{"role": "user", "content": query}, {"role": "system", "content": context}]
+        return self.llm.invoke(messages)
+
+
+class SummarizerAgent:
+    """Summarizes reasoning outputs."""
+
+    def __init__(self, llm):
+        self.llm = llm
+
+    def run(self, text: str) -> str:
+        """Produce a concise summary."""
+        return self.llm.invoke([{"role": "system", "content": text}])

--- a/rag_pipeline/config.py
+++ b/rag_pipeline/config.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from pathlib import Path
+from chromadb import Client
+from chromadb.config import Settings
+from langchain.embeddings import OpenAIEmbeddings
+
+
+@dataclass
+class EmbeddingConfig:
+    """Configuration for embedding models."""
+    model: str = "text-embedding-3-small"
+
+    def create(self):
+        """Instantiate the embedding model."""
+        return OpenAIEmbeddings(model=self.model)
+
+
+@dataclass
+class VectorStoreConfig:
+    """Configuration for the vector database."""
+    persist_directory: str = "vector_db"
+    collection_name: str = "documents"
+
+    def create(self, embedding):
+        """Initialize the Chroma vector store."""
+        client = Client(Settings(persist_directory=str(Path(self.persist_directory))))
+        return client.get_or_create_collection(name=self.collection_name, embedding_function=embedding)

--- a/rag_pipeline/memory.py
+++ b/rag_pipeline/memory.py
@@ -1,0 +1,26 @@
+from collections import deque
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+
+
+@dataclass
+class ConversationMemory:
+    """Persistent storage for recent conversation context."""
+    path: Path = Path("conversation.json")
+    size: int = 5
+    messages: deque = field(init=False)
+
+    def __post_init__(self):
+        self.messages = deque(maxlen=self.size)
+        if self.path.exists():
+            self.messages.extend(json.loads(self.path.read_text()))
+
+    def add(self, role, content):
+        """Append a message to the memory."""
+        self.messages.append({"role": role, "content": content})
+        self.path.write_text(json.dumps(list(self.messages)))
+
+    def get(self):
+        """Return the stored conversation history."""
+        return list(self.messages)

--- a/rag_pipeline/workflow.py
+++ b/rag_pipeline/workflow.py
@@ -1,0 +1,85 @@
+from typing import Dict, List, TypedDict
+from langgraph.graph import StateGraph, END
+
+
+class RAGState(TypedDict, total=False):
+    query: str
+    metadata: Dict
+    docs: List[Dict]
+    confidence: float
+    answer: str
+    history: List[Dict]
+    fallback: bool
+
+
+class RAGWorkflow:
+    """Main workflow graph for retrieval-augmented generation."""
+
+    def __init__(self, retriever, deep_retriever, reasoner, summarizer, memory, threshold: float = 0.5):
+        self.retriever = retriever
+        self.deep_retriever = deep_retriever
+        self.reasoner = reasoner
+        self.summarizer = summarizer
+        self.memory = memory
+        self.threshold = threshold
+        self.app = self._build()
+
+    def _build(self):
+        graph = StateGraph(RAGState)
+
+        def retrieve_primary(state: RAGState):
+            state["docs"] = self.retriever.retrieve(state["query"], state.get("metadata"))
+            return state
+
+        def score_primary(state: RAGState):
+            scores = [d["score"] for d in state["docs"]]
+            state["confidence"] = sum(scores) / len(scores) if scores else 0
+            return state
+
+        def route_primary(state: RAGState):
+            return "reason" if state["confidence"] >= self.threshold else "deep"
+
+        def retrieve_secondary(state: RAGState):
+            state["docs"] = self.deep_retriever.retrieve(state["query"], state.get("metadata"))
+            return state
+
+        def score_secondary(state: RAGState):
+            scores = [d["score"] for d in state["docs"]]
+            state["confidence"] = sum(scores) / len(scores) if scores else 0
+            if state["confidence"] < self.threshold:
+                state["fallback"] = True
+            return state
+
+        def reason(state: RAGState):
+            state["answer"] = self.reasoner.run(state["query"], state["docs"], state["history"])
+            return state
+
+        def summarize(state: RAGState):
+            state["answer"] = self.summarizer.run(state["answer"])
+            return state
+
+        graph.add_node("retrieve_primary", retrieve_primary)
+        graph.add_node("score_primary", score_primary)
+        graph.add_node("retrieve_secondary", retrieve_secondary)
+        graph.add_node("score_secondary", score_secondary)
+        graph.add_node("reason", reason)
+        graph.add_node("summarize", summarize)
+
+        graph.set_entry_point("retrieve_primary")
+        graph.add_edge("retrieve_primary", "score_primary")
+        graph.add_conditional_edges("score_primary", route_primary, {"reason": "reason", "deep": "retrieve_secondary"})
+        graph.add_edge("retrieve_secondary", "score_secondary")
+        graph.add_edge("score_secondary", "reason")
+        graph.add_edge("reason", "summarize")
+        graph.add_edge("summarize", END)
+
+        return graph.compile()
+
+    def run(self, query: str, metadata: Dict | None = None) -> str:
+        """Execute the graph for a query."""
+        history = self.memory.get()
+        state: RAGState = {"query": query, "metadata": metadata or {}, "history": history}
+        result = self.app.invoke(state)
+        self.memory.add("user", query)
+        self.memory.add("assistant", result["answer"])
+        return result["answer"]


### PR DESCRIPTION
## Summary
- add modular agents for retrieval, reasoning, and summarization
- build configurable LangGraph workflow with multi-hop retrieval and confidence gating
- include chat history memory and vector store setup

## Testing
- `python -m py_compile rag_pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac306fbb648333aea34a5153277546