### PR TITLE
Implement LangGraph-based RAG workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# rag-pipeline-with-agents
+# RAG Pipeline with LangGraph
+
+A retrieval-augmented generation system using LangGraph and Chroma.
+
+Provides query refinement, cached multi-hop retrieval, document ingestion, conversation memory, and fallback reasoning when confidence is low.

--- a/rag_pipeline/__init__.py
+++ b/rag_pipeline/__init__.py
@@ -1,0 +1,24 @@
+from .config import EmbeddingConfig, VectorStoreConfig
+from .agents import (
+    RetrieverAgent,
+    ReasoningAgent,
+    FallbackReasoningAgent,
+    SummarizerAgent,
+    QueryRewriterAgent,
+)
+from .ingest import DocumentIngestor
+from .memory import ConversationMemory
+from .workflow import RAGWorkflow
+
+__all__ = [
+    "EmbeddingConfig",
+    "VectorStoreConfig",
+    "RetrieverAgent",
+    "ReasoningAgent",
+    "FallbackReasoningAgent",
+    "SummarizerAgent",
+    "QueryRewriterAgent",
+    "DocumentIngestor",
+    "ConversationMemory",
+    "RAGWorkflow",
+]

--- a/rag_pipeline/agents.py
+++ b/rag_pipeline/agents.py
@@ -1,0 +1,173 @@
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional
+
+
+class RetrieverAgent:
+    """Interactively fetches documents from the vector store.
+
+    Parameters
+    ----------
+    collection: Any
+        Chroma collection interface used for queries.
+    k: int, optional
+        Maximum number of documents to return.
+
+    Notes
+    -----
+    Results are cached for repeated queries with identical metadata filters to
+    minimize vector store requests.
+    """
+
+    def __init__(self, collection: Any, k: int = 5) -> None:
+        self.collection = collection
+        self.k = k
+        self._cache: OrderedDict[str, List[Dict[str, Any]]] = OrderedDict()
+
+    def retrieve(self, query: str, metadata: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+        """Return documents relevant to a query.
+
+        Parameters
+        ----------
+        query: str
+            Natural language search string.
+        metadata: dict, optional
+            Key-value pairs used for metadata filtering.
+
+        Returns
+        -------
+        list of dict
+            Retrieved documents enriched with metadata and similarity score.
+        """
+        key = f"{query}|{tuple(sorted((metadata or {}).items()))}"
+        if key in self._cache:
+            return self._cache[key]
+        filters = {"where": metadata} if metadata else {}
+        result = self.collection.query(query_texts=[query], n_results=self.k, **filters)
+        documents = result["documents"][0]
+        metadatas = result["metadatas"][0]
+        distances = result["distances"][0]
+        docs = [{"text": d, "metadata": m, "score": 1 - s} for d, m, s in zip(documents, metadatas, distances)]
+        self._cache[key] = docs
+        return docs
+
+
+class ReasoningAgent:
+    """Produces a response by reasoning over retrieved documents.
+
+    Parameters
+    ----------
+    llm: Any
+        Chat model implementing an ``invoke`` method compatible with LangChain
+        style interfaces.
+    """
+
+    def __init__(self, llm: Any) -> None:
+        self.llm = llm
+
+    def run(self, query: str, docs: List[Dict[str, Any]], history: List[Dict[str, str]]) -> str:
+        """Generate an answer from user query and context.
+
+        Parameters
+        ----------
+        query: str
+            Original user question.
+        docs: list of dict
+            Documents produced by retrieval agents.
+        history: list of dict
+            Prior conversation messages with roles and content.
+
+        Returns
+        -------
+        str
+            Model-generated answer conditioned on documents and history.
+        """
+        context = "\n".join(d["text"] for d in docs)
+        messages = history + [{"role": "user", "content": query}, {"role": "system", "content": context}]
+        return self.llm.invoke(messages)
+
+
+class FallbackReasoningAgent:
+    """Generates responses when retrieval confidence is insufficient.
+
+    Parameters
+    ----------
+    llm: Any
+        Chat model used for fallback generation.
+    """
+
+    def __init__(self, llm: Any) -> None:
+        self.llm = llm
+
+    def run(self, query: str, history: List[Dict[str, str]]) -> str:
+        """Return a best-effort answer without retrieved context.
+
+        Parameters
+        ----------
+        query: str
+            User question.
+        history: list of dict
+            Prior conversation messages.
+
+        Returns
+        -------
+        str
+            Answer produced solely from the conversation context.
+        """
+        messages = history + [{"role": "user", "content": query}]
+        return self.llm.invoke(messages)
+
+
+class SummarizerAgent:
+    """Condenses verbose answers into concise summaries.
+
+    Parameters
+    ----------
+    llm: Any
+        Chat model used for summarization tasks.
+    """
+
+    def __init__(self, llm: Any) -> None:
+        self.llm = llm
+
+    def run(self, text: str) -> str:
+        """Produce a concise summary of given text.
+
+        Parameters
+        ----------
+        text: str
+            Full reasoning response to summarize.
+
+        Returns
+        -------
+        str
+            Shortened summary string.
+        """
+        return self.llm.invoke([{"role": "system", "content": text}])
+
+
+class QueryRewriterAgent:
+    """Refines user queries to improve retrieval quality.
+
+    Parameters
+    ----------
+    llm: Any
+        Language model used to produce refined queries.
+    """
+
+    def __init__(self, llm: Any) -> None:
+        self.llm = llm
+
+    def run(self, query: str) -> str:
+        """Return a reformulated query string.
+
+        Parameters
+        ----------
+        query: str
+            Original user question.
+
+        Returns
+        -------
+        str
+            Improved query expected to yield better retrieval results.
+        """
+        return self.llm.invoke([{"role": "user", "content": query}])

--- a/rag_pipeline/config.py
+++ b/rag_pipeline/config.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+from pathlib import Path
+from chromadb import Client
+from chromadb.config import Settings
+from langchain.embeddings import OpenAIEmbeddings
+
+
+@dataclass
+class EmbeddingConfig:
+    """Configuration container for embedding models.
+
+    Parameters
+    ----------
+    model: str
+        Name of the embedding model exposed by the provider.
+    """
+
+    model: str = "text-embedding-3-small"
+
+    def create(self) -> OpenAIEmbeddings:
+        """Instantiate the embedding model.
+
+        Returns
+        -------
+        OpenAIEmbeddings
+            Configured embedding model instance.
+        """
+        return OpenAIEmbeddings(model=self.model)
+
+
+@dataclass
+class VectorStoreConfig:
+    """Configuration for persistent vector storage.
+
+    Parameters
+    ----------
+    persist_directory: str
+        Filesystem path where Chroma will store its database.
+    collection_name: str
+        Identifier for the document collection.
+    """
+
+    persist_directory: str = "vector_db"
+    collection_name: str = "documents"
+
+    def create(self, embedding: OpenAIEmbeddings):
+        """Initialize or retrieve the Chroma collection.
+
+        Parameters
+        ----------
+        embedding: OpenAIEmbeddings
+            Embedding function used for indexing and similarity search.
+
+        Returns
+        -------
+        Any
+            Chroma collection instance tied to the configured directory and name.
+        """
+        client = Client(Settings(persist_directory=str(Path(self.persist_directory))))
+        return client.get_or_create_collection(name=self.collection_name, embedding_function=embedding)

--- a/rag_pipeline/ingest.py
+++ b/rag_pipeline/ingest.py
@@ -1,0 +1,33 @@
+from typing import Any, Dict, List
+
+
+class DocumentIngestor:
+    """Adds documents to the vector store with optional metadata.
+
+    Parameters
+    ----------
+    collection: Any
+        Chroma collection interface used for insertion.
+    """
+
+    def __init__(self, collection: Any) -> None:
+        self.collection = collection
+
+    def add(self, texts: List[str], metadatas: List[Dict[str, Any]]) -> None:
+        """Insert documents into the collection.
+
+        Parameters
+        ----------
+        texts: list of str
+            Raw document strings to embed and store.
+        metadatas: list of dict
+            Metadata entries aligned with each text.
+
+        Returns
+        -------
+        None
+            Method performs side effects only.
+        """
+        ids = [str(i) for i in range(len(texts))]
+        self.collection.add(documents=texts, metadatas=metadatas, ids=ids)
+

--- a/rag_pipeline/memory.py
+++ b/rag_pipeline/memory.py
@@ -1,0 +1,55 @@
+from collections import deque
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+@dataclass
+class ConversationMemory:
+    """Persistent storage for recent conversation context.
+
+    Parameters
+    ----------
+    path: Path, optional
+        Filesystem location used to store serialized messages.
+    size: int, optional
+        Maximum number of recent exchanges to retain.
+    """
+
+    path: Path = Path("conversation.json")
+    size: int = 5
+    messages: deque = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.messages = deque(maxlen=self.size)
+        if self.path.exists():
+            self.messages.extend(json.loads(self.path.read_text()))
+
+    def add(self, role: str, content: str) -> None:
+        """Append a message to the memory.
+
+        Parameters
+        ----------
+        role: str
+            Message author, typically ``user`` or ``assistant``.
+        content: str
+            Textual content of the message.
+
+        Returns
+        -------
+        None
+            Method performs side effects only.
+        """
+        self.messages.append({"role": role, "content": content})
+        self.path.write_text(json.dumps(list(self.messages)))
+
+    def get(self) -> List[Dict[str, str]]:
+        """Return the stored conversation history.
+
+        Returns
+        -------
+        list of dict
+            Sequence of messages with roles and content.
+        """
+        return list(self.messages)

--- a/rag_pipeline/workflow.py
+++ b/rag_pipeline/workflow.py
@@ -1,0 +1,150 @@
+from typing import Any, Dict, List, Optional, TypedDict
+from langgraph.graph import StateGraph, END
+
+
+class RAGState(TypedDict, total=False):
+    query: str
+    rewritten: str
+    metadata: Dict[str, Any]
+    docs: List[Dict[str, Any]]
+    confidence: float
+    answer: str
+    history: List[Dict[str, str]]
+    fallback: bool
+
+
+class RAGWorkflow:
+    """Main workflow graph orchestrating retrieval and reasoning.
+
+    Parameters
+    ----------
+    rewriter: Any
+        Agent responsible for query refinement.
+    retriever: Any
+        Primary retrieval agent.
+    deep_retriever: Any
+        Secondary retrieval agent for low-confidence results.
+    reasoner: Any
+        Agent that synthesizes responses using documents and history.
+    fallback_reasoner: Any
+        Agent used when retrieval remains low-confidence after secondary search.
+    summarizer: Any
+        Agent providing concise summaries of reasoning output.
+    memory: Any
+        Storage for recent conversation history.
+    threshold: float, optional
+        Minimum confidence required to avoid secondary retrieval.
+    """
+
+    def __init__(
+        self,
+        rewriter: Any,
+        retriever: Any,
+        deep_retriever: Any,
+        reasoner: Any,
+        fallback_reasoner: Any,
+        summarizer: Any,
+        memory: Any,
+        threshold: float = 0.5,
+    ) -> None:
+        self.rewriter = rewriter
+        self.retriever = retriever
+        self.deep_retriever = deep_retriever
+        self.reasoner = reasoner
+        self.fallback_reasoner = fallback_reasoner
+        self.summarizer = summarizer
+        self.memory = memory
+        self.threshold = threshold
+        self.app = self._build()
+
+    def _build(self):
+        graph = StateGraph(RAGState)
+
+        def rewrite(state: RAGState) -> RAGState:
+            state["rewritten"] = self.rewriter.run(state["query"])
+            return state
+
+        def retrieve_primary(state: RAGState) -> RAGState:
+            state["docs"] = self.retriever.retrieve(state["rewritten"], state.get("metadata"))
+            return state
+
+        def score_primary(state: RAGState) -> RAGState:
+            scores = [d["score"] for d in state["docs"]]
+            state["confidence"] = sum(scores) / len(scores) if scores else 0
+            return state
+
+        def route_primary(state: RAGState) -> str:
+            return "reason" if state["confidence"] >= self.threshold else "deep"
+
+        def retrieve_secondary(state: RAGState) -> RAGState:
+            more = self.deep_retriever.retrieve(state["rewritten"], state.get("metadata"))
+            combined = {d["text"]: d for d in state["docs"]}
+            for doc in more:
+                combined.setdefault(doc["text"], doc)
+            state["docs"] = list(combined.values())
+            return state
+
+        def score_secondary(state: RAGState) -> RAGState:
+            scores = [d["score"] for d in state["docs"]]
+            state["confidence"] = sum(scores) / len(scores) if scores else 0
+            if state["confidence"] < self.threshold:
+                state["fallback"] = True
+            return state
+
+        def route_secondary(state: RAGState) -> str:
+            return "fallback" if state.get("fallback") else "reason"
+
+        def reason(state: RAGState) -> RAGState:
+            state["answer"] = self.reasoner.run(state["query"], state["docs"], state["history"])
+            return state
+
+        def fallback(state: RAGState) -> RAGState:
+            state["answer"] = self.fallback_reasoner.run(state["query"], state["history"])
+            return state
+
+        def summarize(state: RAGState) -> RAGState:
+            state["answer"] = self.summarizer.run(state["answer"])
+            return state
+
+        graph.add_node("rewrite", rewrite)
+        graph.add_node("retrieve_primary", retrieve_primary)
+        graph.add_node("score_primary", score_primary)
+        graph.add_node("retrieve_secondary", retrieve_secondary)
+        graph.add_node("score_secondary", score_secondary)
+        graph.add_node("reason", reason)
+        graph.add_node("fallback", fallback)
+        graph.add_node("summarize", summarize)
+
+        graph.set_entry_point("rewrite")
+        graph.add_edge("rewrite", "retrieve_primary")
+        graph.add_edge("retrieve_primary", "score_primary")
+        graph.add_conditional_edges("score_primary", route_primary, {"reason": "reason", "deep": "retrieve_secondary"})
+        graph.add_edge("retrieve_secondary", "score_secondary")
+        graph.add_conditional_edges("score_secondary", route_secondary, {"fallback": "fallback", "reason": "reason"})
+        graph.add_edge("reason", "summarize")
+        graph.add_edge("fallback", "summarize")
+        graph.add_edge("summarize", END)
+
+        return graph.compile()
+
+    def run(self, query: str, metadata: Optional[Dict[str, Any]] = None) -> str:
+        """Execute the graph for a user query.
+
+        Parameters
+        ----------
+        query: str
+            Raw user question.
+        metadata: dict, optional
+            Additional constraints for retrieval filtering.
+
+        Returns
+        -------
+        str
+            Final summarized answer produced by the workflow.
+        """
+        history = self.memory.get()
+        state: RAGState = {"query": query, "metadata": metadata or {}, "history": history}
+        result = self.app.invoke(state)
+        self.memory.add("user", query)
+        self.memory.add("assistant", result["answer"])
+        return result["answer"]


### PR DESCRIPTION
## Summary
- add fallback reasoning agent for low-confidence queries
- route workflow through fallback reasoning when secondary retrieval fails
- document fallback capability in README

## Testing
- `python -m py_compile rag_pipeline/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac306fbb648333aea34a5153277546