### PR TITLE
Add ranked RAG flow using LangChain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,8 @@ A retrieval-augmented generation system using LangGraph and Chroma.
 2. Ingest documents: `python -m rag_pipeline.ingest`
 3. Create a `RAGWorkflow` instance and call `run` with a query
  
+
+## Ranked RAG Flow
+A simplified LangChain-based pipeline is available in `ranked_rag/`.
+It demonstrates document ranking with dense ranks, a chain-of-thought
+reasoning prompt, and a reflexive self-critique step.

--- a/ranked_rag/__init__.py
+++ b/ranked_rag/__init__.py
@@ -1,0 +1,5 @@
+"""Enhanced RAG flow with ranking, chain of thought, and reflexion."""
+
+from .workflow import run_ranked_rag
+
+__all__ = ["run_ranked_rag"]

--- a/ranked_rag/chain_of_thought.py
+++ b/ranked_rag/chain_of_thought.py
@@ -1,0 +1,13 @@
+"""Chain-of-thought utilities using LangChain."""
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+COT_PROMPT = PromptTemplate(
+    template="Question: {question}\nLet's think step by step.",
+    input_variables=["question"],
+)
+
+
+def get_chain(llm) -> LLMChain:
+    """Construct an LLMChain that encourages step-by-step reasoning."""
+    return LLMChain(llm=llm, prompt=COT_PROMPT)

--- a/ranked_rag/ranking.py
+++ b/ranked_rag/ranking.py
@@ -1,0 +1,27 @@
+"""Utilities for ranking retrieved documents."""
+from typing import List, Dict, Any
+
+
+def dense_rank(documents: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Return documents sorted by score with dense rank assigned.
+
+    Parameters
+    ----------
+    documents: List[Dict[str, Any]]
+        Each document should contain a ``score`` key.
+
+    Returns
+    -------
+    List[Dict[str, Any]]
+        Documents sorted by descending score with an added ``rank`` field.
+    """
+    sorted_docs = sorted(documents, key=lambda d: d.get("score", 0), reverse=True)
+    last_score = None
+    rank = 0
+    for doc in sorted_docs:
+        score = doc.get("score", 0)
+        if score != last_score:
+            rank += 1
+            last_score = score
+        doc["rank"] = rank
+    return sorted_docs

--- a/ranked_rag/reflex.py
+++ b/ranked_rag/reflex.py
@@ -1,0 +1,19 @@
+"""Self-reflection utilities."""
+from langchain.prompts import PromptTemplate
+from langchain.chains import LLMChain
+
+REFLEX_PROMPT = PromptTemplate(
+    template=(
+        "You are reviewing an answer for correctness and completeness.\n"
+        "Question: {question}\n"
+        "Answer: {answer}\n"
+        "Provide constructive feedback and a refined answer."
+    ),
+    input_variables=["question", "answer"],
+)
+
+
+def reflex(llm, question: str, answer: str) -> str:
+    """Generate a reflection on the answer using the provided LLM."""
+    chain = LLMChain(llm=llm, prompt=REFLEX_PROMPT)
+    return chain.run(question=question, answer=answer)

--- a/ranked_rag/workflow.py
+++ b/ranked_rag/workflow.py
@@ -1,0 +1,33 @@
+"""Workflow assembling ranking, chain-of-thought reasoning, and reflexion."""
+from typing import Any, Dict, List
+from langchain.schema import Document
+
+from .ranking import dense_rank
+from .chain_of_thought import get_chain
+from .reflex import reflex
+
+
+def run_ranked_rag(query: str, retriever: Any, llm: Any) -> Dict[str, Any]:
+    """Run a simple ranked RAG flow.
+
+    Parameters
+    ----------
+    query: str
+        User question.
+    retriever: Any
+        Object exposing ``get_relevant_documents`` and returning ``Document`` objects.
+    llm: Any
+        LLM used for reasoning and reflexion.
+    """
+    docs: List[Document] = retriever.get_relevant_documents(query)
+    scored_docs = [
+        {"text": d.page_content, "score": d.metadata.get("score", 0)} for d in docs
+    ]
+    ranked = dense_rank(scored_docs)
+
+    cot_chain = get_chain(llm)
+    context = "\n\n".join(doc["text"] for doc in ranked)
+    answer = cot_chain.run(question=f"{query}\n\nContext:\n{context}")
+
+    critique = reflex(llm, query, answer)
+    return {"answer": answer, "critique": critique, "documents": ranked}


### PR DESCRIPTION
## Summary
- add `ranked_rag` module featuring document ranking with dense ranks
- implement chain-of-thought prompt and reflexive critique utilities
- document new flow in README

## Testing
- `python -m py_compile ranked_rag/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae83b11b748333bb77fd672937b11a